### PR TITLE
Enable CTB in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Strapi gives you many possible deployment options for your project including [St
 yarn strapi deploy
 ```
 
+## Enabling Content Type Builder in Production
+
+This template enables the Content Type Builder plugin even when running in production. You can add or update content types through the admin panel without switching environments. To disable this behaviour, remove the plugin configuration from `config/plugins.js`.
+
 ## 📚 Learn more
 
 - [Resource center](https://strapi.io/resource-center) - Strapi resource center.

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,1 +1,6 @@
-module.exports = () => ({});
+module.exports = ({ env }) => ({
+  // Enable the Content Type Builder plugin even when running in production
+  'content-type-builder': {
+    enabled: true,
+  },
+});


### PR DESCRIPTION
## Summary
- allow content type builder plugin in production
- document how to disable it

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684561854c3c8328ac897187c48704f9